### PR TITLE
Complete the invitation message

### DIFF
--- a/.github/workflows/invitation.yml
+++ b/.github/workflows/invitation.yml
@@ -13,6 +13,6 @@ jobs:
           organization: The-Lively-Developers-Community
           label: invite me to the organisation
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          comment: '<b>Invitation sent to join the GitHub Organisation. Welcome to the community 🎉</b><br>ublic so it appears on your GitHub profile for everyone else to see. You can do this by finding your name in the GitHub organisation list and change the dropdown to public https://github.com/orgs/The-Lively-Developers-Community/people<br><br>Tips for practising:<br>'
+          comment: "<b>Invitation sent to join the GitHub Organisation. Welcome to the community 🎉</b><br>Don't forget to make it public so it appears on your GitHub profile for everyone else to see. You can do this by finding your name in the GitHub organisation list and change the dropdown to public https://github.com/orgs/The-Lively-Developers-Community/people<br><br><b>HAPPY CODING</b><br>"
         env:
           INVITE_TOKEN: ${{ secrets.INVITE_TOKEN }}

--- a/.github/workflows/invitation.yml
+++ b/.github/workflows/invitation.yml
@@ -13,6 +13,6 @@ jobs:
           organization: The-Lively-Developers-Community
           label: invite me to the organisation
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          comment: "<b>Invitation sent to join the GitHub Organisation. Welcome to the community 🎉</b><br>Don't forget to make it public so it appears on your GitHub profile for everyone else to see. You can do this by finding your name in the GitHub organisation list and change the dropdown to public https://github.com/orgs/The-Lively-Developers-Community/people<br><br><b>HAPPY CODING</b><br>"
+          comment: "<b>Invitation sent to join the GitHub Organisation. Welcome to the community 🎉</b><br>Don't forget to make the Community public on your profile, so it appears on your GitHub profile for everyone else to see. You can do this by finding your name in the GitHub organisation list and change the dropdown to public https://github.com/orgs/The-Lively-Developers-Community/people<br><br><b>HAPPY CODING</b><br>"
         env:
           INVITE_TOKEN: ${{ secrets.INVITE_TOKEN }}


### PR DESCRIPTION
When I received the invitation I got a message that read:

_"Invitation sent to join the GitHub Organisation. Welcome to the community
ublic so it appears on your GitHub profile for everyone else to see. You can do this by finding your name in the GitHub organisation list and change the dropdown to public https://github.com/orgs/The-Lively-Developers-Community/people_

_Tips for practising:"_

This is due to the yml code having the incomplete message.